### PR TITLE
Handle missing artifacts gracefully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: lint_debug_log
-        path: artifacts/lint_debug_log.log3
+        path: artifacts/lint_debug_log.log
         if-no-files-found: "ignore"
+  
     - name: Create ID Set
       run: |
         demisto-sdk create-id-set -o artifacts/pack_id_set.json
@@ -68,6 +69,8 @@ jobs:
       with:
         name: id_set
         path: artifacts/id_set.json
+        if-no-files-found: "error"
+
     - name: Validate all packs
       run: |
         git fetch
@@ -82,3 +85,4 @@ jobs:
       with:
         name: content_packs
         path: artifacts/content_packs.zip
+        if-no-files-found: "error"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
         if [ ! "$(ls -A Packs)" ]; then
           echo No files in Packs
-          # tools/update_helloworld_example.sh
+          tools/update_helloworld_example.sh
         fi
 
         tools/update_repo.sh
@@ -50,7 +50,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: lint_debug_log
-        path: artifacts/lint_debug_log.log
+        path: artifacts/lint_debug_log.log3
         if-no-files-found: "ignore"
     - name: Create ID Set
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
         if [ ! "$(ls -A Packs)" ]; then
           echo No files in Packs
-          tools/update_helloworld_example.sh
+          # tools/update_helloworld_example.sh
         fi
 
         tools/update_repo.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,11 @@ jobs:
         mkdir artifacts
         demisto-sdk lint -a --log-file-path ./artifacts/lint_debug_log.log
     - name: Archive unit test results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: lint_debug_log
         path: artifacts/lint_debug_log.log
+        if-no-files-found: "ignore"
     - name: Create ID Set
       run: |
         demisto-sdk create-id-set -o artifacts/pack_id_set.json
@@ -63,7 +64,7 @@ jobs:
 
     - name: Upload ID set file to artifacts
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: id_set
         path: artifacts/id_set.json
@@ -77,7 +78,7 @@ jobs:
       run: demisto-sdk create-content-artifacts --artifacts_path artifacts
     - name: Archive Content Packs zip
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: content_packs
         path: artifacts/content_packs.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         name: lint_debug_log
         path: artifacts/lint_debug_log.log
-        if-no-files-found: "ignore"
+        if-no-files-found: "ignore" # lint may not create a file if the repo has no code files [CIAC-7718]
   
     - name: Create ID Set
       run: |


### PR DESCRIPTION
bumped `upload-artifact` to `v4`, and now:
1. If a lint output file is missing (happens when lint has no files to run on), it's ignored instead of failing. (see provided argument)
2. If other artifacts (id-set, content artifacts) are not available during their upload stage, fail (preserving previous behavior)
fixes: [CIAC-7718](https://jira-dc.paloaltonetworks.com/browse/CIAC-7718)