### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         # Version range or exact version of a Python version to use, using SemVer's version range syntax.
         python-version: "3.10"
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -37,7 +37,7 @@ jobs:
         fi
 
         tools/update_repo.sh
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: '12'
     - run: npm ci
@@ -47,7 +47,7 @@ jobs:
         mkdir artifacts
         demisto-sdk lint -a --log-file-path ./artifacts/lint_debug_log.log
     - name: Archive unit test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: lint_debug_log
         path: artifacts/lint_debug_log.log
@@ -65,7 +65,7 @@ jobs:
 
     - name: Upload ID set file to artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: id_set
         path: artifacts/id_set.json
@@ -81,7 +81,7 @@ jobs:
       run: demisto-sdk create-content-artifacts --artifacts_path artifacts
     - name: Archive Content Packs zip
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: content_packs
         path: artifacts/content_packs.zip


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions